### PR TITLE
Update wa2latex.py

### DIFF
--- a/wa2latex.py
+++ b/wa2latex.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
                 line = re.sub("([a-zA-Z0-9-_]+).jpg", r'\n\\begin{figure}[H]\n' +
                     r'\\includegraphics[cfbox=lightgray 0.5pt 0pt, width=\\textwidth,keepaspectratio]{' + media_att.group(0) + r'}\n' +
                     r'\\end{figure}\n', line)
-                continue
+               
 
             # Remove timestamps
             line = re.sub("\d{2}:\d{2}:\d{2}:\s", "", line)


### PR DESCRIPTION
the continue statement makes it so that the latex instructions for images are never printed to file, removing this fixes this.